### PR TITLE
Add LoRA script for IR finetuning on 4 GPUs

### DIFF
--- a/internvl_chat/shell/internvl3.0/2nd_finetune/internvl3_8b_lora_ir_4gpu.sh
+++ b/internvl_chat/shell/internvl3.0/2nd_finetune/internvl3_8b_lora_ir_4gpu.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+set -x
+
+# Hardware configuration
+GPUS=${GPUS:-4}
+BATCH_SIZE=${BATCH_SIZE:-128}
+PER_DEVICE_BATCH_SIZE=${PER_DEVICE_BATCH_SIZE:-8}
+# total batch = GPUS * PER_DEVICE_BATCH_SIZE * GRADIENT_ACC
+GRADIENT_ACC=$(( BATCH_SIZE / (PER_DEVICE_BATCH_SIZE * GPUS) ))
+
+# Environment
+export PYTHONPATH="${PYTHONPATH}:$(pwd)/internvl_chat"
+export MASTER_PORT=${MASTER_PORT:-34229}
+export TF_CPP_MIN_LOG_LEVEL=3
+export LAUNCHER=pytorch
+
+# Output directory
+OUTPUT_DIR="work_dirs/internvl_chat_v3/internvl3_8b_lora_ir_4gpu"
+mkdir -p "${OUTPUT_DIR}"
+
+# Launch training with LoRA using infrared dataset
+torchrun \
+  --nnodes=1 \
+  --node_rank=0 \
+  --master_addr=127.0.0.1 \
+  --nproc_per_node=${GPUS} \
+  --master_port=${MASTER_PORT} \
+  internvl/train/internvl_chat_finetune.py \
+    --model_name_or_path "./pretrained/InternVL3-8B" \
+    --conv_style "internvl2_5" \
+    --output_dir ${OUTPUT_DIR} \
+    --meta_path "./shell/data/dataset_data.json" \
+    --overwrite_output_dir True \
+    --force_image_size 448 \
+    --max_dynamic_patch 12 \
+    --down_sample_ratio 0.5 \
+    --drop_path_rate 0.0 \
+    --freeze_llm True \
+    --freeze_mlp True \
+    --freeze_backbone True \
+    --use_llm_lora 16 \
+    --vision_select_layer -1 \
+    --dataloader_num_workers 4 \
+    --bf16 True \
+    --num_train_epochs 1 \
+    --per_device_train_batch_size ${PER_DEVICE_BATCH_SIZE} \
+    --gradient_accumulation_steps ${GRADIENT_ACC} \
+    --evaluation_strategy "no" \
+    --save_strategy "steps" \
+    --save_steps 200 \
+    --save_total_limit 1 \
+    --learning_rate 4e-5 \
+    --weight_decay 0.05 \
+    --warmup_ratio 0.03 \
+    --lr_scheduler_type "cosine" \
+    --logging_steps 1 \
+    --max_seq_length 16384 \
+    --do_train True \
+    --grad_checkpoint True \
+    --group_by_length True \
+    --dynamic_image_size True \
+    --use_thumbnail True \
+    --ps_version 'v2' \
+    --deepspeed "zero_stage1_config.json" \
+    --report_to "tensorboard" \
+  2>&1 | tee -a "${OUTPUT_DIR}/training_log.txt"


### PR DESCRIPTION
## Summary
- add a new script `internvl3_8b_lora_ir_4gpu.sh` for LoRA finetuning with infrared images
- configure defaults for four GPUs and larger per-device batch size

## Testing
- ❌ `pre-commit run --files internvl_chat/shell/internvl3.0/2nd_finetune/internvl3_8b_lora_ir_4gpu.sh` *(failed: `pre-commit` not installed)*


------
https://chatgpt.com/codex/tasks/task_b_6863fb79a8588321a682d62e72956354