### PR TITLE
Add script for freeze configuration sweeps

### DIFF
--- a/internvl_chat/shell/internvl3.0/2nd_finetune/run_freeze_combinations.sh
+++ b/internvl_chat/shell/internvl3.0/2nd_finetune/run_freeze_combinations.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -e
+set -x
+
+# Print environment info
+echo "CONDA_DEFAULT_ENV: $CONDA_DEFAULT_ENV"  # should be "internvl3"
+echo "python -> $(which python)"
+echo "python exec -> $(python -c 'import sys;print(sys.executable)')"
+export PATH="$CONDA_PREFIX/bin:$HOME/.local/bin:$PATH"
+echo "torchrun -> $(which torchrun)"
+echo "PATH -> $PATH"
+
+GPUS=4
+BATCH_SIZE=${BATCH_SIZE:-128}
+PER_DEVICE_BATCH_SIZE=${PER_DEVICE_BATCH_SIZE:-4}
+GRADIENT_ACC=$((BATCH_SIZE / PER_DEVICE_BATCH_SIZE / GPUS))
+
+export PYTHONPATH="${PYTHONPATH}:$(pwd)/internvl_chat"
+export MASTER_PORT=34229
+export TF_CPP_MIN_LOG_LEVEL=3
+export LAUNCHER=pytorch
+
+BASE_OUTPUT_DIR='work_dirs/internvl_chat_v3'
+
+for freeze_llm in True False; do
+  for freeze_mlp in True False; do
+    for freeze_backbone in True False; do
+      if [ "$freeze_llm" = "True" ] && [ "$freeze_mlp" = "False" ] && [ "$freeze_backbone" = "False" ]; then
+        echo "Skip freeze_llm=${freeze_llm} freeze_mlp=${freeze_mlp} freeze_backbone=${freeze_backbone} (already run)"
+        continue
+      fi
+
+      OUTPUT_DIR="${BASE_OUTPUT_DIR}/internvl3_8b_dynamic_res_2nd_finetune_llm${freeze_llm}_mlp${freeze_mlp}_backbone${freeze_backbone}"
+      mkdir -p "${OUTPUT_DIR}"
+
+      torchrun \
+        --nnodes=1 \
+        --node_rank=0 \
+        --master_addr=127.0.0.1 \
+        --nproc_per_node=${GPUS} \
+        --master_port=${MASTER_PORT} \
+        internvl_chat/internvl/train/internvl_chat_finetune.py \
+        --model_name_or_path "./pretrained/InternVL3-8B" \
+        --conv_style "internvl2_5" \
+        --use_fast_tokenizer False \
+        --output_dir ${OUTPUT_DIR} \
+        --meta_path "./shell/data/dataset_data.json" \
+        --overwrite_output_dir True \
+        --force_image_size 448 \
+        --max_dynamic_patch 12 \
+        --down_sample_ratio 0.5 \
+        --drop_path_rate 0.0 \
+        --freeze_llm ${freeze_llm} \
+        --freeze_mlp ${freeze_mlp} \
+        --freeze_backbone ${freeze_backbone} \
+        --vision_select_layer -1 \
+        --dataloader_num_workers 4 \
+        --bf16 True \
+        --num_train_epochs 1 \
+        --per_device_train_batch_size ${PER_DEVICE_BATCH_SIZE} \
+        --gradient_accumulation_steps ${GRADIENT_ACC} \
+        --evaluation_strategy "no" \
+        --save_strategy "steps" \
+        --save_steps 200 \
+        --save_total_limit 1 \
+        --learning_rate 2e-5 \
+        --weight_decay 0.05 \
+        --warmup_ratio 0.03 \
+        --lr_scheduler_type "cosine" \
+        --logging_steps 1 \
+        --max_seq_length 16384 \
+        --do_train True \
+        --grad_checkpoint True \
+        --group_by_length True \
+        --dynamic_image_size True \
+        --use_thumbnail True \
+        --ps_version 'v2' \
+        --deepspeed "zero_stage1_config.json" \
+        --report_to "tensorboard" \
+        2>&1 | tee -a "${OUTPUT_DIR}/training_log.txt"
+    done
+  done
+done
+


### PR DESCRIPTION
## Summary
- add `run_freeze_combinations.sh` which iterates over all freeze parameter combinations except the one already run
- logs each run and places output in configuration-named directories

## Testing
- `bash -n internvl_chat/shell/internvl3.0/2nd_finetune/run_freeze_combinations.sh`


------
https://chatgpt.com/codex/tasks/task_b_6874b5e1ee208321970e3efecf9cb406